### PR TITLE
Integrate with Backstage (Modify Me!)

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -1,0 +1,58 @@
+name: Publish TechDocs Site
+
+on:
+  push:
+    branches: [master]
+    # Set it to run only when TechDocs related files are updated.
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
+jobs:
+  publish-techdocs-site:
+    runs-on: ubuntu-latest
+    
+    env:
+      TECHDOCS_S3_BUCKET_NAME: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      ENTITY_NAMESPACE: 'default'
+      ENTITY_KIND: 'Component'
+
+      ENTITY_NAME: 'new-relic-deploy-marker-buildkite-plugin'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install techdocs-cli
+        run: sudo npm install -g @techdocs/cli
+
+      - name: Install mkdocs and mkdocs plugins
+        run: python -m pip install mkdocs-techdocs-core==0.*
+
+      - name: Generate docs site
+        run: techdocs-cli generate --no-docker --verbose
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+
+          role-duration-seconds: 900
+          role-session-name: github-actions-publish-techdocs
+
+      - name: Publish docs site
+        run:
+          techdocs-cli publish --publisher-type awsS3 --storage-name
+          $TECHDOCS_S3_BUCKET_NAME --entity
+          $ENTITY_NAMESPACE/$ENTITY_KIND/$ENTITY_NAME

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,30 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: new-relic-deploy-marker-buildkite-plugin
+  description: 
+  links:
+    - title: Website
+      url: https://github.com/cultureamp/new-relic-deploy-marker-buildkite-plugin
+  # - title: Confluence
+  #   url: confluence.com/project-page
+  # - title: Monitoring Dashboard
+  #   url: datadog.com/this-service
+  # - title: Logs
+  #   url: splunk.com/service?filters
+  tags: # required and based on - https://cultureamp.atlassian.net/wiki/spaces/CPlatform/pages/1720156463/Authentication+-+One+Platform+Technical+Canvas
+    - tier-1
+  annotations:
+    github.com/project-slug: cultureamp/new-relic-deploy-marker-buildkite-plugin
+    github.com/team-slug: cultureamp/sre 
+    backstage.io/techdocs-ref: url:https://github.com/cultureamp/blob/master/new-relic-deploy-marker-buildkite-plugin
+    buildkite.com/project-slug: culture-amp/new-relic-deploy-marker-buildkite-plugin
+    # pagerduty.com/integration-key: optional
+spec:
+  type: default
+  owner: sre
+  # system: 
+  # subcomponentOf: 
+  # consumesApis: 
+  # providesApis: 
+  lifecycle: production

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+Holding file for Docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: ''
+site_description: ''
+
+plugins:
+  - techdocs-core
+
+nav:
+  - Overview:
+    - Placeholder: 'index.md'


### PR DESCRIPTION
The purpose of this PR is to add the configuration required such that your component can be registered in our software catalogue - <link to backstage> (Access)

It is strongly recommended you review and change this PR.
Please consult the backstage docs and reach out to Mark Walford or the central SRE team #team_sre with any questions

This PR does the following.

1. Adds a `catalog-info.yaml` file. This file contains metadata about the repo and is read by backstage when the component is registered.
2. Adds a `mkdocs.yml` file. This file defines the backstage techdocs nav and document location (usually ./docs this folder is created if it does not already exist)
  Consult the cultureamp/backstage repo for an example https://github.com/cultureamp/backstage/blob/development/mkdocs.yml
3. Adds a github workflow that compiles the docs in the repo and pushes them to s3 for consumption from backstage

Notes:

- The `catalog-info.yaml` is not complete. Consult the backstage docs to complete accurately
- The doc workflow will not work until either 1) We add org wide aws access secrets to github actions for consumption or 2) A buildkite pipeline step is added that executes this workflow passing aws access secrets. In both cases this workflow will still be used to publish the docs.